### PR TITLE
Remove innternal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.grammarkit.tasks.*
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 plugins {
     id("java") // Java support
@@ -133,6 +134,7 @@ intellijPlatform {
     }
 
     pluginVerification {
+        failureLevel = VerifyPluginTask.FailureLevel.ALL - listOf(VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES)
         ides {
             recommended()
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = net.exoego.intellij.digdag
 pluginName = digdag
 pluginRepositoryUrl = https://github.com/exoego/intellij-digdag
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = 0.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242

--- a/src/main/kotlin/net/exoego/intellij/digdag/psi/impl/DigdagBlockScalarImpl.kt
+++ b/src/main/kotlin/net/exoego/intellij/digdag/psi/impl/DigdagBlockScalarImpl.kt
@@ -9,7 +9,6 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
-import com.intellij.psi.util.ReadActionCachedValue
 import com.intellij.util.SmartList
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.text.splitLineRanges
@@ -59,15 +58,6 @@ abstract class DigdagBlockScalarImpl(node: ASTNode) : DigdagScalarImpl(node) {
             }, PsiModificationTracker.MODIFICATION_COUNT
         )
     }
-
-    // it is a memory optimisation
-    private val textCache: ReadActionCachedValue<String> = ReadActionCachedValue { super.getText() }
-
-    override fun getText(): String = textCache.getCachedOrEvaluate()
-
-    private val validCache: ReadActionCachedValue<Boolean> = ReadActionCachedValue { super.isValid() }
-
-    override fun isValid(): Boolean = validCache.getCachedOrEvaluate()
 
     protected open val includeFirstLineInContent: Boolean get() = false
 


### PR DESCRIPTION
0.0.1 was rejected due to usage of internal API

> The [latest update of your plugin](https://plugins.jetbrains.com/plugin/25667-digdag/edit/versions/stable/624282) uses API annotated with org.jetbrains.annotations.ApiStatus.Internal. Such APIs are private and cannot be used outside the IntelliJ Platform itself.
To find a recommended replacement API, please check [this article](https://plugins.jetbrains.com/docs/intellij/api-internal.html). After that, please upload your plugin to Marketplace again. If the API of your update is not listed there, please let us know, and we will help you to find the replacement API.